### PR TITLE
Removing MerkleTree::from_vec_unsafe.

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -28,7 +28,7 @@ fn bench_small_str_tree(b: &mut Bencher) {
 fn bench_small_str_proof_gen(b: &mut Bencher) {
     let digest = Sha3::sha3_256();
     let values = vec!["one", "two", "three", "four"];
-    let tree   = MerkleTree::from_vec_unsafe(digest, values.clone());
+    let tree   = MerkleTree::from_vec(digest, values.clone()).unwrap();
 
     b.iter(|| {
         for value in &values {
@@ -42,7 +42,7 @@ fn bench_small_str_proof_gen(b: &mut Bencher) {
 fn bench_small_str_proof_check(b: &mut Bencher) {
     let digest = Sha3::sha3_256();
     let values = vec!["one", "two", "three", "four"];
-    let tree   = MerkleTree::from_vec_unsafe(digest, values.clone());
+    let tree   = MerkleTree::from_vec(digest, values.clone()).unwrap();
     let proofs = values.iter().map(|v| tree.gen_proof(v).unwrap()).collect::<Vec<_>>();
 
     b.iter(|| {
@@ -63,7 +63,7 @@ fn bench_big_rnd_tree(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        MerkleTree::from_vec_unsafe(digest, values.clone())
+        MerkleTree::from_vec(digest, values.clone()).unwrap()
     });
 }
 
@@ -77,7 +77,7 @@ fn bench_big_rnd_proof_gen(b: &mut Bencher) {
         rng.fill_bytes(&mut v);
     }
 
-    let tree = MerkleTree::from_vec_unsafe(digest, values.clone());
+    let tree = MerkleTree::from_vec(digest, values.clone()).unwrap();
 
     b.iter(|| {
         for value in &values {
@@ -97,7 +97,7 @@ fn bench_big_rnd_proof_check(b: &mut Bencher) {
         rng.fill_bytes(&mut v);
     }
 
-    let tree   = MerkleTree::from_vec_unsafe(digest, values.clone());
+    let tree   = MerkleTree::from_vec(digest, values.clone()).unwrap();
     let proofs = values.into_iter().map(|v| tree.gen_proof(v).unwrap()).collect::<Vec<_>>();
 
     b.iter(|| {

--- a/src/merkletree.rs
+++ b/src/merkletree.rs
@@ -26,13 +26,7 @@ pub struct MerkleTree<D, T> {
 
 impl <D, T> MerkleTree<D, T> where D: Digest + Clone, T: Into<Vec<u8>> + Clone {
 
-    /// Constructs a Merkle Tree from a vector of data blocks.  
-    /// WARNING: Panics if `values` is empty!
-    pub fn from_vec_unsafe(digest: D, values: Vec<T>) -> Self {
-        Self::from_vec(digest, values).unwrap()
-    }
-
-    /// Constructs a Merkle Tree from a vector of data blocks.  
+    /// Constructs a Merkle Tree from a vector of data blocks.
     /// Returns None if `values` is empty.
     pub fn from_vec(mut digest: D, values: Vec<T>) -> Option<Self> {
         if values.is_empty() {
@@ -123,4 +117,3 @@ impl <D, T> MerkleTree<D, T> where D: Digest + Clone, T: Into<Vec<u8>> + Clone {
     }
 
 }
-

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ fn test_from_str_vec() {
     ];
 
     let count = values.len();
-    let tree  = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values);
+    let tree  = MerkleTree::from_vec(Sha3::sha3_256(), values).unwrap();
 
     let h01 = digest.combine_hashes(&hashes[0], &hashes[1]);
     let h23 = digest.combine_hashes(&hashes[2], &hashes[3]);
@@ -38,13 +38,13 @@ fn test_from_str_vec() {
 #[should_panic]
 fn test_from_vec_empty() {
     let values: Vec<Vec<u8>> = vec![];
-    MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values);
+    MerkleTree::from_vec(Sha3::sha3_256(), values).unwrap();
 }
 
 #[test]
 fn test_from_vec1() {
     let values = vec!["hello, world".to_string()];
-    let tree   = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values);
+    let tree   = MerkleTree::from_vec(Sha3::sha3_256(), values).unwrap();
 
     let mut d     = Sha3::sha3_256();
     let root_hash = &d.hash_bytes(&"hello, world".as_bytes());
@@ -58,7 +58,7 @@ fn test_from_vec1() {
 #[test]
 fn test_from_vec3() {
     let values = vec![vec![1], vec![2], vec![3]];
-    let tree   = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values);
+    let tree   = MerkleTree::from_vec(Sha3::sha3_256(), values).unwrap();
 
     let mut d = Sha3::sha3_256();
 
@@ -80,7 +80,7 @@ fn test_from_vec3() {
 #[test]
 fn test_from_vec9() {
     let values = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
-    let tree   = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values.clone());
+    let tree   = MerkleTree::from_vec(Sha3::sha3_256(), values.clone()).unwrap();
 
     let mut d = Sha3::sha3_256();
 
@@ -105,7 +105,7 @@ fn test_from_vec9() {
 #[test]
 fn test_valid_proof() {
     let values    = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
-    let tree      = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values.clone());
+    let tree      = MerkleTree::from_vec(Sha3::sha3_256(), values.clone()).unwrap();
     let root_hash = tree.root_hash();
 
     for value in values {
@@ -119,7 +119,7 @@ fn test_valid_proof() {
 #[test]
 fn test_valid_proof_str() {
     let values    = vec!["Hello", "my", "name", "is", "Rusty"];
-    let tree      = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values.clone());
+    let tree      = MerkleTree::from_vec(Sha3::sha3_256(), values.clone()).unwrap();
     let root_hash = tree.root_hash();
 
     let value = "Rusty";
@@ -133,10 +133,10 @@ fn test_valid_proof_str() {
 #[test]
 fn test_wrong_proof() {
     let values1   = vec![vec![1], vec![2], vec![3], vec![4]];
-    let tree1     = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values1.clone());
+    let tree1     = MerkleTree::from_vec(Sha3::sha3_256(), values1.clone()).unwrap();
 
     let values2   = vec![vec![4], vec![5], vec![6], vec![7]];
-    let tree2     = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values2.clone());
+    let tree2     = MerkleTree::from_vec(Sha3::sha3_256(), values2.clone()).unwrap();
 
     let root_hash = tree2.root_hash();
 
@@ -151,7 +151,7 @@ fn test_wrong_proof() {
 #[test]
 fn test_mutate_proof_first_lemma() {
     let values    = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
-    let tree      = MerkleTree::from_vec_unsafe(Sha3::sha3_256(), values.clone());
+    let tree      = MerkleTree::from_vec(Sha3::sha3_256(), values.clone()).unwrap();
     let root_hash = tree.root_hash();
 
     let mut i = 0;
@@ -177,4 +177,3 @@ fn test_mutate_proof_first_lemma() {
         i += 1;
     }
 }
-

--- a/tests/proto.rs
+++ b/tests/proto.rs
@@ -13,7 +13,7 @@ fn test_protobuf_inverse() {
     let digest = Sha3::sha3_256();
     let values = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
 
-    let tree = MerkleTree::from_vec_unsafe(digest.clone(), values.clone());
+    let tree = MerkleTree::from_vec(digest.clone(), values.clone()).unwrap();
 
     for value in values {
         let proof = tree.gen_proof(value).unwrap();
@@ -25,4 +25,3 @@ fn test_protobuf_inverse() {
         assert_eq!(proof.lemma, res.lemma);
     }
 }
-


### PR DESCRIPTION
We can leave it up to the developer to implement the unwrap behaviour.