### PR TITLE
use *ring* 0.9 to reduce build dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ homepage      = "https://github.com/SpinResearch/merkle.rs"
 repository    = "https://github.com/SpinResearch/merkle.rs"
 
 [dependencies]
-ring = "^0.6.0"
+ring = "^0.9"
 protobuf = { version = "^1.2.0", optional = true }
 
 [features]


### PR DESCRIPTION
*ring* 0.9 no longer requires GNU Make, Perl, MSBuild, or a C++
compiler. Building *ring* 0.9 on Windows, in particular, is much
easier. This in turn makes it easier to build this crate.