### PR TITLE
Add serde support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased](https://github.com/SpinResearch/merkle.rs/compare/1.6.0...master)
 
+- Support serde with the feature flag `serialization-serde`.
+
 > Nothing yet.
 
 ## [1.6.0](https://github.com/SpinResearch/merkle.rs/compare/1.5.0...1.6.0) - 2018-05-15

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,15 @@ categories    = ["data-structures", "cryptography"]
 [dependencies]
 ring = "^0.12.0"
 protobuf = { version = "^1.6.0", optional = true }
+serde = { version = "^1.0.55", optional = true }
+serde_derive = { version = "^1.0.55", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0.17"
 
 [features]
 serialization-protobuf = [ "protobuf" ]
+serialization-serde = [ "serde", "serde_derive" ]
 
 [package.metadata.release]
 sign-commit = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@ extern crate ring;
 #[cfg(feature = "serialization-protobuf")]
 extern crate protobuf;
 
+#[cfg(feature = "serialization-serde")]
+extern crate serde;
+#[cfg(feature = "serialization-serde")]
+#[macro_use]
+extern crate serde_derive;
+
 mod merkletree;
 pub use merkletree::MerkleTree;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,3 +275,15 @@ fn test_custom_hashable_impl() {
     assert_eq!(tree.count(), 10);
     assert_eq!(tree.height(), 4);
 }
+
+#[cfg(feature = "serialization-serde")]
+#[test]
+fn test_serialize_proof_with_serde() {
+    extern crate serde_json;
+
+    let values = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
+    let tree = MerkleTree::from_vec(digest, values);
+    let proof = tree.gen_proof(vec![5]);
+    let serialized = serde_json::to_string(&proof).expect("serialize proof");
+    assert_eq!(proof, serde_json::from_str(&serialized).expect("deserialize proof"));
+}


### PR DESCRIPTION
This adds the `serialization-serde` feature, which implements
serde's `Serialize` and `Deserialize` traits for `Proof` and `Lemma`.

Fixes #30