### PR TITLE
Serde tests and minor fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
-#![deny(missing_docs, unused_qualifications, missing_debug_implementations,
-        missing_copy_implementations, trivial_casts, trivial_numeric_casts, unsafe_code,
-        unstable_features, unused_import_braces)]
+#![deny(
+    missing_docs, unused_qualifications, missing_debug_implementations,
+    missing_copy_implementations, trivial_casts, trivial_numeric_casts, unsafe_code,
+    unstable_features, unused_import_braces
+)]
 
 //! *merkle* implements a Merkle Tree in Rust.
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -5,9 +5,9 @@ use ring::digest::Algorithm;
 pub use self::proof::{LemmaProto, ProofProto};
 use proof::{Lemma, Positioned, Proof};
 
-use protobuf::Message;
 use protobuf::error::ProtobufResult;
 use protobuf::parse_from_bytes;
+use protobuf::Message;
 
 impl<T> Proof<T> {
     /// Constructs a `Proof` struct from its Protobuf representation.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,8 @@
 #![cfg(test)]
 
+#[cfg(feature = "serialization-serde")]
+extern crate serde_json;
+
 use ring::digest::{Algorithm, Context, SHA512};
 
 use hashutils::{HashUtils, Hashable};
@@ -275,12 +278,12 @@ fn test_custom_hashable_impl() {
 #[cfg(feature = "serialization-serde")]
 #[test]
 fn test_serialize_proof_with_serde() {
-    extern crate serde_json;
-
     let values = (1..10).map(|x| vec![x]).collect::<Vec<_>>();
     let tree = MerkleTree::from_vec(digest, values);
     let proof = tree.gen_proof(vec![5]);
+
     let serialized = serde_json::to_string(&proof).expect("serialize proof");
+
     assert_eq!(
         proof,
         serde_json::from_str(&serialized).expect("deserialize proof")


### PR DESCRIPTION
* Got rid of the double reference in the serialize function.
* Added tests for mod algorithm_serde. Had to place them where they are because the module is private. We could reorganize public/ privateness of modules so they could be in the tests module though if preferred.
* Ran rustfmt so Travis will pass.