### PR TITLE
Update to latest rust-protobuf to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       before_script:
         - rustup component add rustfmt-preview
       script:
-        - cargo fmt --all -- --write-mode=diff
+        - cargo fmt --all -- --check
     - env: NAME='kcov'
       sudo: required # travis-ci/travis-ci#9061
       before_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories    = ["data-structures", "cryptography"]
 
 [dependencies]
 ring = "^0.12.0"
-protobuf = { version = "^1.6.0", optional = true }
+protobuf = { version = "^2.0.2", optional = true }
 serde = { version = "^1.0.55", optional = true }
 serde_derive = { version = "^1.0.55", optional = true }
 

--- a/src/merkletree.rs
+++ b/src/merkletree.rs
@@ -28,7 +28,9 @@ pub struct MerkleTree<T> {
 impl<T: PartialEq> PartialEq for MerkleTree<T> {
     #[allow(trivial_casts)]
     fn eq(&self, other: &MerkleTree<T>) -> bool {
-        self.root == other.root && self.height == other.height && self.count == other.count
+        self.root == other.root
+            && self.height == other.height
+            && self.count == other.count
             && (self.algorithm as *const Algorithm) == (other.algorithm as *const Algorithm)
     }
 }


### PR DESCRIPTION
Fixes #39. I think what upstream did was break compatibility with 1.5 when they released 1.6 and then fixed compatibility with 1.7. So we adjusted to 1.6 in #29, but then that adjustment became wrong in 1.7. The 2.0.2 release is working fine, and is similar to 1.6. Since it seems like they got the version together (kind of), I decided nay on the tilde requirements, though we can always do that if they ever break semver again.