### PR TITLE
Bump ring dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories    = ["data-structures", "cryptography"]
 
 
 [dependencies]
-ring = "^0.12.0"
+ring = "^0.13.0"
 protobuf = { version = "^2.0.2", optional = true }
 serde = { version = "^1.0.55", optional = true }
 serde_derive = { version = "^1.0.55", optional = true }


### PR DESCRIPTION
This is currently the only outdated dependency